### PR TITLE
Add R2 Bucket Manager to Workers Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [GitHub Action](https://github.com/cpilsworth/cloudflare-worker-action) - Deploy a worker on push to the master branch.
 - [Workers KV Viewer](https://github.com/jroyal/cloudflare-workers-kv-viewer) - CLI based interactive viewer for workers KV storage.
 - [Redirect Management](https://forwarding.app) - Generate redirect worker.
+- [R2 Bucket Manager](https://github.com/neverinfamous/R2-Manager-Worker) - Full-featured web app for managing Cloudflare R2 buckets with GitHub SSO via Zero Trust.
 
 ### Recipes
 


### PR DESCRIPTION
## Description

This PR adds [R2 Bucket Manager](https://github.com/neverinfamous/R2-Manager-Worker) to the "Workers" → "Tools" section of awesome-cloudflare.

## About R2 Bucket Manager

R2 Bucket Manager is a full-featured web application for managing Cloudflare R2 buckets, built specifically for the Cloudflare ecosystem.

### Key Features:
- Built on Cloudflare Workers
- GitHub SSO authentication via Cloudflare Zero Trust
- Complete R2 bucket management functionality  
- Drag-and-drop file uploads
- Demo available at https://r2.adamic.tech/

The entry has been added alphabetically after "Redirect Management" in the Workers Tools section.

## MIT License

R2 Bucket Manager is released under the MIT license.