### PR TITLE
Add Absurdity Index

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [Support](https://support.cloudflare.com)
 - [System Status](https://www.cloudflarestatus.com)
 - [Network Map](https://www.cloudflare.com/network)
+- [Absurdity Index](https://absurdityindex.org) - Satirical congressional legislation scoring site on Pages + Workers.
 
 ## Contribute
 


### PR DESCRIPTION
## Add Absurdity Index to Other

**Site**: [absurdityindex.org](https://absurdityindex.org)

Satirical congressional legislation scoring site deployed on Pages with Workers for API endpoints and middleware. Uses Pages Functions for server-side logic including dynamic API routes.

Added to the bottom of the "Other" section, following the contribution guidelines (description starts with capital, ends with period, does not mention Cloudflare or start with "A"/"An").