### PR TITLE
Add Redirect Checker - HTTP redirect chain analyzer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,8 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
 
+- [Redirect Checker](https://github.com/brancogao/redirect-checker) - HTTP redirect chain analyzer with loop detection and performance measurement.
+
 ## Other
 
 - [Support](https://support.cloudflare.com)


### PR DESCRIPTION
## Description

Added [Redirect Checker](https://github.com/brancogao/redirect-checker) to the Recipes section.

## What it does

Redirect Checker is an HTTP redirect chain analyzer built on Cloudflare Workers:
- Trace complete redirect chains (301, 302, 307, 308)
- Detect redirect loops
- Measure performance impact at each hop
- Test with different User-Agents (Googlebot, Bingbot, Mobile)
- RESTful API for integration

## Why it fits

This project is:
- Built entirely on Cloudflare Workers
- Open source (MIT license)
- Demonstrates Workers capabilities (fetch API, edge computing)
- Useful for developers and SEO professionals

## Links

- Demo: https://redirect-checker.autocompany.workers.dev/
- Source: https://github.com/brancogao/redirect-checker