### PR TITLE
Add Gabe — cron job heartbeat monitor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [Performance Optimized Workers](https://github.com/pmeenan/cf-workers) - Collection of worker scripts, generally focused on performance optimizations.
 - [Google reCAPTCHA verification](https://github.com/HR/recaptcha-worker) - Handle the server-side verification of your reCAPTCHA form.
 - [Cloudflare Workers Starter Kit](https://github.com/kriasoft/cloudflare-starter-kit) -  - TypeScript template \w multiple CF Workers, `*.env` files, and local testing.
+- [Gabe](https://github.com/Scolliq/gabe) - Lightweight cron job heartbeat monitor with webhook alerts, using Workers and KV.
 
 ### AI
 


### PR DESCRIPTION
Adds [Gabe](https://github.com/Scolliq/gabe) to the Workers Recipes section.

Gabe is a lightweight cron job heartbeat monitor built entirely on Cloudflare Workers + KV. Developers append a curl to their crontab — if the ping stops arriving, Gabe sends webhook alerts to Slack/Discord.

- Open source (MIT)
- Self-hostable on Workers free tier
- No database or Docker required
- npm CLI available (`gabe-monitor`)