### PR TITLE
Add PageGuard - free website health scanner on Workers + D1 + Workers AI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 ### AI
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
-- [PageGuard](https://github.com/sleepyxpad-jpg/pageguard) - Free website health scanner built on Workers + D1 + Workers AI. Checks SEO, Performance, Accessibility, and Best Practices with an AI-generated action plan.
+- [PageGuard](https://pageguard.org) - Free website health scanner built on Workers + D1 + Workers AI. Checks SEO, Performance, Accessibility, and Best Practices with an AI-generated action plan.
 
 ## Other
 

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 ### AI
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
+- [PageGuard](https://github.com/sleepyxpad-jpg/pageguard) - Free website health scanner built on Workers + D1 + Workers AI. Checks SEO, Performance, Accessibility, and Best Practices with an AI-generated action plan.
 
 ## Other
 


### PR DESCRIPTION
## PageGuard — Free Website Health Scanner

**GitHub**: https://github.com/sleepyxpad-jpg/pageguard  
**Live demo**: https://pageguard.qiudeqiu.workers.dev

### What it does

PageGuard is a free website health scanner that runs on Cloudflare Workers. It checks:

- SEO (meta tags, structured data, Open Graph)
- Performance (Core Web Vitals via Google PageSpeed Insights API)
- Accessibility (WCAG 2.1)
- Best Practices (HTTPS, image formats, deprecated APIs)
- AI-generated action plan (Cloudflare Workers AI / Llama 3.1 8B)
- Scan history with score trend comparison

### Tech stack (all Cloudflare)

- **Cloudflare Workers** — compute
- **Cloudflare D1** — scan history (SQLite at the edge)
- **Cloudflare Workers AI** — Llama 3.1 8B for plain-English report generation

### Why it fits awesome-cloudflare

This is a complete, production-deployed example of using Workers + D1 + Workers AI together in a real application. No Docker, no VMs, total infra cost at 0–1K users/day is $0.

Added to the **AI** section since it showcases Workers AI in a real product context.