### PR TITLE
Add x402 AI API to Workers section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 ### AI
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
+- [x402 AI API](https://api.zeroreader.com) - 29 AI models via x402 micropayments on Workers. Pay-per-request with USDC.
 
 ## Other
 


### PR DESCRIPTION
Add x402 AI API entry to the AI subsection of the Workers section.

x402 AI API provides 29 AI models on Cloudflare Workers with pay-per-request pricing using USDC micropayments via the x402 protocol. No API keys required.

- Link: https://api.zeroreader.com
- 29 AI models available
- Pay-per-request with USDC micropayments
- Runs on Cloudflare Workers