### PR TITLE
Add Pushduck to Workers Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [GitHub Action](https://github.com/cpilsworth/cloudflare-worker-action) - Deploy a worker on push to the master branch.
 - [Workers KV Viewer](https://github.com/jroyal/cloudflare-workers-kv-viewer) - CLI based interactive viewer for workers KV storage.
 - [Redirect Management](https://forwarding.app) - Generate redirect worker.
+- [Pushduck](https://github.com/abhay-ramesh/pushduck) - File upload library with R2 storage support, presigned URLs, and React hooks.
 
 ### Recipes
 


### PR DESCRIPTION
## Description

Adding [Pushduck](https://github.com/abhay-ramesh/pushduck) to the Workers > Tools section.

Pushduck is a file upload library that runs natively on Cloudflare Workers with R2 storage support. It uses presigned URLs for direct browser-to-storage uploads, has zero AWS SDK dependency (uses `aws4fetch` instead), and provides React hooks for frontend integration. It supports R2's S3-compatible API out of the box.

**Why it belongs here:** It's specifically designed to work on edge runtimes including Cloudflare Workers, and has first-class support for Cloudflare R2 as a storage backend.

- Repository: https://github.com/abhay-ramesh/pushduck