### PR TITLE
Add Beam Analytics — privacy-first analytics built on Workers/D1/KV

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [Official OSS Apps](https://github.com/cloudflare-apps) - Collection of official apps.
 - [Logflare](https://github.com/Logflare/cloudflare-app) - Log management & event analytics.
 - [OpWork.dev](https://github.com/hisorange/opwork) - Self hosted CloudFlare workers management platform.
-- [Beam Analytics](https://beam.keylightdigital.com/) - Privacy-first web analytics built entirely on Cloudflare Workers, D1, and KV. Cookie-free, GDPR compliant, with custom events, goals, and traffic source analysis. Open-source tracking script. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js))
+- [Beam Analytics](https://beam-privacy.com/) - Privacy-first web analytics built entirely on Cloudflare Workers, D1, and KV. Cookie-free, GDPR compliant, with custom events, goals, and traffic source analysis. Open-source tracking script. ([Demo](https://beam-privacy.com/demo), [Source](https://github.com/scobb/beam.js))
 
 ## Workers
 

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [Official OSS Apps](https://github.com/cloudflare-apps) - Collection of official apps.
 - [Logflare](https://github.com/Logflare/cloudflare-app) - Log management & event analytics.
 - [OpWork.dev](https://github.com/hisorange/opwork) - Self hosted CloudFlare workers management platform.
+- [Beam Analytics](https://beam.keylightdigital.com/) - Privacy-first web analytics built entirely on Cloudflare Workers, D1, and KV. Cookie-free, GDPR compliant, with custom events, goals, and traffic source analysis. Open-source tracking script. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js))
 
 ## Workers
 


### PR DESCRIPTION
## Add Beam Analytics

Adding [Beam](https://beam-privacy.com/) to Apps → Open Source as an example of a complete, production-grade analytics application built entirely on the Cloudflare stack.

**Tech stack:**
- **Runtime:** Cloudflare Workers (Hono framework)
- **Database:** D1 (SQLite at the edge)
- **Cache/KV:** Workers KV
- **Deploy:** Wrangler

**Why it belongs here:**
- Built 100% on Cloudflare Workers + D1 + KV — a reference implementation for the full stack
- Privacy-first, cookie-free analytics (GDPR compliant)
- Open-source tracking script: https://github.com/scobb/beam.js
- Live managed service at https://beam-privacy.com/
- Free tier: 1 site, 50K pv/mo. Pro: $5/mo, unlimited sites, 500K pv/mo

**Live demo:** https://beam-privacy.com/demo
**Tracking script source:** https://github.com/scobb/beam.js