### PR TITLE
Add Nexus - open-source AI agent observability on Cloudflare Workers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,8 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
 
+- [Nexus](https://nexus.keylightdigital.dev/) - Open-source AI agent observability platform built on Workers and D1. Track traces, spans, and errors from autonomous agents. TypeScript SDK. $9/mo Pro.
+
 ## Other
 
 - [Support](https://support.cloudflare.com)


### PR DESCRIPTION
## Submitting Nexus to awesome-cloudflare

**[Nexus](https://nexus.keylightdigital.dev/)** is an open-source AI agent observability platform built entirely on the Cloudflare stack.

**Why it belongs here:**
- Built on Cloudflare Workers (Hono framework), D1 (SQLite), and KV — 100% Cloudflare-native
- TypeScript SDK: `npm install @keylightdigital/nexus`
- Open-source: https://github.com/scobb/nexus
- Live product: https://nexus.keylightdigital.dev

**Category:** Workers > AI (added to the bottom of the existing section, after Moltworker)

**Format follows contribution guidelines:** `[title](link) - Description.`

This is a real product, not a demo — deployed and accessible at nexus.keylightdigital.dev.
