### PR TITLE
Add Shirabe — Japan-specific AI-native API platform (Calendar + Address)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 ### AI
 
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
+- [Shirabe](https://shirabe.dev) - Japan-specific AI-native API platform built on Hono + Workers with edge caching. Provides Japanese calendar API (六曜 rokuyo, 暦注 rekichu auspicious days, 24 solar terms) and Address normalization API (ABR-backed, all 47 prefectures, CC BY 4.0). OpenAPI 3.1 specs + MCP server + GPT Actions for direct AI agent consumption. [Calendar repo](https://github.com/techwell-inc-jp/shirabe-calendar-api), [Address repo](https://github.com/techwell-inc-jp/shirabe-address-api).
 
 ## Other
 


### PR DESCRIPTION
## Review the Contributing Guidelines

**By submitting this pull request, I promise I have read the [contributing guidelines](https://github.com/irazasyed/awesome-cloudflare/blob/master/contributing.md) and ensured my submission follows it.**

## Describe Why This Is Awesome

Adding **Shirabe** to the Workers > AI section.

Shirabe is a production Cloudflare Workers-based API platform that exposes Japan-specific knowledge to AI agents:

- **Calendar API** — Japanese rokuyo (六曜) / rekichu (暦注) / eto (干支) / 24 solar terms with 8-category auspicious-day scoring. MCP-compatible.
- **Address API** — Japanese address normalization backed by ABR (Digital Agency of Japan, CC BY 4.0). All 47 prefectures, WGS84 coordinates.

### Why Cloudflare Workers

- Edge runtime fits AI agent workload (short request bursts from LLM calls, global distribution)
- KV for stats / API keys, D1 for large datasets (address API uses Fly.io volume for geocoder, but Workers-first architecture)
- Hono framework for clean REST + streaming SSE
- OpenAPI 3.1 with bilingual (Japanese + English) descriptions on every endpoint
- Stripe Billing with `transform_quantity` for metered usage

### Fit for the AI section

Currently the Workers > AI subsection only has `Moltworker`. Shirabe extends this with production-grade, AI-agent-consumable APIs demonstrating a real-world Workers + AI use case for domain-specific knowledge delivery.

- Main site: https://shirabe.dev
- Calendar repo (MIT): https://github.com/techwell-inc-jp/shirabe-calendar-api
- Address repo (MIT): https://github.com/techwell-inc-jp/shirabe-address-api
- Operator: Techwell Inc. (株式会社テックウェル), Fukuoka, Japan
