### PR TITLE
Add Mandu — fullstack framework with Cloudflare Workers adapter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [GitHub Action](https://github.com/cpilsworth/cloudflare-worker-action) - Deploy a worker on push to the master branch.
 - [Workers KV Viewer](https://github.com/jroyal/cloudflare-workers-kv-viewer) - CLI based interactive viewer for workers KV storage.
 - [Redirect Management](https://forwarding.app) - Generate redirect worker.
+- [Mandu](https://mandujs.com) - Agent-native fullstack framework on Bun + React with a built-in Cloudflare Workers adapter — `mandu deploy --to=cloudflare` generates `wrangler.toml` and ships routes, static assets, and edge functions in one command.
 
 ### Recipes
 


### PR DESCRIPTION
Adds [Mandu](https://mandujs.com) under **Workers → Tools**.

Mandu is a Bun + React fullstack framework with a first-class Cloudflare Workers adapter — `mandu deploy --to=cloudflare` generates `wrangler.toml` and ships routes, static assets, and edge functions in one command. Other relevant bits for the Cloudflare audience:

- File-system routing under `app/**/page.tsx`
- Static prerender (deployable to Cloudflare Pages) plus per-route SSR/Edge handlers
- Runtime architecture **Guard** rejects layer/import violations as the dev server runs
- 100+ MCP tools so AI editors (Claude Code / Cursor / OpenAI Codex / GitHub Copilot) can drive scaffolding and deploys directly

Source: https://github.com/konamgil/mandu  ·  docs: https://mandujs.com

Happy to adjust the description if it should be tighter to match neighbouring entries.