### PR TITLE
Add ContextMCP under Workers > AI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 
 ### AI
 
+- [ContextMCP](https://github.com/dodopayments/context-mcp) - Self-hosted Model Context Protocol (MCP) server for documentation, deployed on Workers. Indexes Mintlify, Fumadocs, Docusaurus, Markdown & OpenAPI into Pinecone and serves it to AI assistants (Claude, Cursor, etc.) via MCP and a REST API.
 - [Moltworker](https://github.com/cloudflare/moltworker) - Run Moltbot (formely Clawdbot) on Cloudflare Workers.
 
 ## Other


### PR DESCRIPTION
## What

Adds **ContextMCP** to the "Workers > AI" section.

## Why this fits

ContextMCP is built specifically to deploy on Cloudflare Workers — the deployed Worker exposes the Streamable HTTP MCP endpoint that AI assistants (Claude, Cursor, Continue, etc.) connect to. It's a real-world demonstration of Workers serving a non-trivial production AI workload (vector search + MCP protocol).

## About ContextMCP

Self-hosted MCP server that turns documentation into a searchable knowledge base for AI assistants. Indexes Mintlify, Fumadocs, Docusaurus, plain Markdown, and OpenAPI specs into Pinecone using OpenAI embeddings; serves them via the Model Context Protocol and a REST API. Apache-2.0; production-used by Dodo Payments.

- Repo: https://github.com/dodopayments/context-mcp
- Website: https://contextmcp.ai
- npm: https://www.npmjs.com/package/contextmcp

## Entry added

```markdown
- [ContextMCP](https://github.com/dodopayments/context-mcp) - Self-hosted Model Context Protocol (MCP) server for documentation, deployed on Workers. Indexes Mintlify, Fumadocs, Docusaurus, Markdown & OpenAPI into Pinecone and serves it to AI assistants (Claude, Cursor, etc.) via MCP and a REST API.
```

## Checklist

- [x] Open-source (Apache-2.0)
- [x] Active project, working deployment
- [x] Format matches existing entries
- [x] No duplicate
