### PR TITLE
Add Routup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [Performance Optimized Workers](https://github.com/pmeenan/cf-workers) - Collection of worker scripts, generally focused on performance optimizations.
 - [Google reCAPTCHA verification](https://github.com/HR/recaptcha-worker) - Handle the server-side verification of your reCAPTCHA form.
 - [Cloudflare Workers Starter Kit](https://github.com/kriasoft/cloudflare-starter-kit) -  - TypeScript template \w multiple CF Workers, `*.env` files, and local testing.
+- [Routup](https://github.com/routup/routup) - Runtime-agnostic HTTP routing framework with return-based handlers and tree-shakeable helpers.
 
 ### AI
 


### PR DESCRIPTION
Adds [Routup](https://github.com/routup/routup) — a minimalistic, runtime-agnostic HTTP routing framework with native Workers support via Web standard APIs.

- Repo: https://github.com/routup/routup
- Docs: https://routup.net
- npm: https://www.npmjs.com/package/routup

Added at the bottom of `Workers → Recipes` per the contribution guidelines ("Additions should be added to the bottom of the relevant section").