### PR TITLE
Add Linkshot to Workers > Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ Cloudflare provides content delivery network (CDN) services, DDoS mitigation, In
 - [GitHub Action](https://github.com/cpilsworth/cloudflare-worker-action) - Deploy a worker on push to the master branch.
 - [Workers KV Viewer](https://github.com/jroyal/cloudflare-workers-kv-viewer) - CLI based interactive viewer for workers KV storage.
 - [Redirect Management](https://forwarding.app) - Generate redirect worker.
+- [Linkshot](https://uselinkshot.com) - Open Graph image API powered by Workers and Browser Rendering, with Tailwind CSS injection for capture-only styles.
 
 ### Recipes
 


### PR DESCRIPTION
Adds [Linkshot](https://uselinkshot.com) under `## Workers / ### Tools` (at the bottom, after Redirect Management).

Linkshot is a hosted Open Graph image API built on Workers and Browser Rendering. It screenshots the live URL of a page with a real Chromium browser, optionally injecting Tailwind CSS — including a custom `linkshot:` modifier that activates only during screenshot capture, so navbars, cookie banners, or chat widgets can be hidden in OG images without affecting the live page.

Why include:

- Practical reference for an application built end-to-end on Workers + Browser Rendering
- Demonstrates a non-trivial use of Browser Rendering for production OG image generation
- Public, hosted, free trial — no signup wall to evaluate

Link: https://uselinkshot.com

Format follows contributing.md:

- `[title](link) - Description.` format
- Description does not mention `Cloudflare` (implied)
- Capital start, period end
- Does not start with `A` or `An`
- Added to the bottom of the relevant section